### PR TITLE
[DI - step 2] 코맥 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 3. 드라이버는 30분 간격으로 교체한다.
 4. TDD로 할 수 있다면 최대한 적용한다.
 
-## 요구사항
+## step-1 요구사항
 
 - @Service, @Repository 클래스 스캔
     
@@ -17,11 +17,12 @@
 - @Inject에 필요한 객체를 찾아서 주입 / 생성
 - 기존의 @Controller를 스캔하는 ControllerScanner 클래스를 확장된 BeanScanner와 통합
 
-## TO DO
-- `BeanFactoryUtils.getInjectedConstructor` 메서드에서 `@Inject`가 붙은 생성자가 여러개일 때 처리 방법 고민 
--  BeanScannerTest 추가
-    - base 패키지 바깥의 클래스를 스캔하지 않는지 확인
-    - 다른 종류의 애노테이션이 선언된 클래스를 스캔하지 않는지 확인
+## step-2 요구사항
+
+- @Configuration 어노테이션으로 빈 설정
     
- ## 의문 사항
- - 테스트 코드를 작성하면서 테스트만을 위한 패키지를 만드는 것에 대해 어떻게 생각하시나요?
+    1. @ComponentScan
+    2. @Bean으로 빈 수동 생성
+    
+    @Configuration을 찾고 @ComponentScan의 값을 BeanScanner에 전달하여 빈 생성
+    @Configuration도 빈으로 등록하여 내부의 @Bean 메서드 결과를 빈으로 등록한다.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@
     
     @Configuration을 찾고 @ComponentScan의 값을 BeanScanner에 전달하여 빈 생성
     @Configuration도 빈으로 등록하여 내부의 @Bean 메서드 결과를 빈으로 등록한다.
+
+
+### 의문사항
+- `@ComponentScan` 어노테이션에 value와 basepackage가 공통된 정보를 나타내서 이를 어떻게 처리해야할지 궁금합니다.

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanCreator.java
@@ -1,0 +1,9 @@
+package nextstep.di.factory;
+
+import java.lang.reflect.InvocationTargetException;
+
+@FunctionalInterface
+public interface BeanCreator {
+
+    Object create(Object concreteObject, Object... objects) throws IllegalAccessException, InvocationTargetException, InstantiationException;
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinition.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinition.java
@@ -1,0 +1,33 @@
+package nextstep.di.factory;
+
+import java.util.List;
+
+public class BeanDefinition {
+    private Class<?> type;
+    private Class<?> configType;
+    private BeanCreator beanCreator;
+    private List<Class<?>> parameters;
+
+    public BeanDefinition(Class<?> type, Class<?> configType, BeanCreator beanCreator, List<Class<?>> parameters) {
+        this.type = type;
+        this.configType = configType;
+        this.beanCreator = beanCreator;
+        this.parameters = parameters;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public Class<?> getConfigType() {
+        return configType;
+    }
+
+    public BeanCreator getBeanCreator() {
+        return beanCreator;
+    }
+
+    public List<Class<?>> getParameters() {
+        return parameters;
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionCreator.java
@@ -1,0 +1,9 @@
+package nextstep.di.factory;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface BeanDefinitionCreator {
+
+    Map<Class<?>, BeanDefinition> create(Set<Class<?>> preInstantiateClasses);
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
@@ -1,0 +1,95 @@
+package nextstep.di.factory;
+
+import com.google.common.collect.Maps;
+import nextstep.annotation.Bean;
+import nextstep.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BeanDefinitionFactory {
+    private static final Logger logger = LoggerFactory.getLogger(BeanDefinitionFactory.class);
+
+    private final Set<Class<?>> preInstantiateClasses;
+
+    public BeanDefinitionFactory(Set<Class<?>> preInstantiateClasses) {
+        this.preInstantiateClasses = preInstantiateClasses;
+    }
+
+    public Map<Class<?>, BeanDefinition> createBeanDefinition() {
+        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
+
+        for (Class<?> preInstantiateClass : preInstantiateClasses) {
+            Constructor<?> injectedConstructor = createInjectedConstructor(preInstantiateClass);
+            definitions.put(preInstantiateClass, createBeanDefinition(preInstantiateClass, injectedConstructor));
+            createBeanDefinitionsOfConfiguration(definitions, preInstantiateClass);
+        }
+
+        return definitions;
+    }
+
+    private Constructor<?> createInjectedConstructor(Class concreteClass) {
+        Constructor<?> injectedConstructor = BeanFactoryUtils.getInjectedConstructor(concreteClass);
+
+        return injectedConstructor == null ? getDefaultConstructor(concreteClass) : injectedConstructor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor getDefaultConstructor(Class concreteClass) {
+        try {
+            return concreteClass.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            logger.error(e.getMessage(), e);
+            throw new BeanCreationFailException(e);
+        }
+    }
+
+    // TODO: 19. 11. 14. 메서드 매개변수로 선언된 definitions 리팩토링
+    private void createBeanDefinitionsOfConfiguration(Map<Class<?>, BeanDefinition> definitions, Class<?> clazz) {
+        if (clazz.isAnnotationPresent(Configuration.class)) {
+            Method[] declaredMethods = clazz.getDeclaredMethods();
+            List<Method> beanCreators = getBeanCreators(declaredMethods);
+            addBeanDefinition(definitions, beanCreators);
+        }
+    }
+
+    private List<Method> getBeanCreators(Method[] declaredMethods) {
+        return Stream.of(declaredMethods)
+                .filter(method -> method.isAnnotationPresent(Bean.class))
+                .collect(Collectors.toList());
+    }
+
+    private void addBeanDefinition(Map<Class<?>, BeanDefinition> definitions, List<Method> beanCreations) {
+        for (Method beanCreation : beanCreations) {
+            Class<?> beanType = beanCreation.getReturnType();
+            Class<?> configType = beanCreation.getDeclaringClass();
+            definitions.put(beanType, createBeanDefinition(beanType, configType, beanCreation));
+        }
+    }
+
+    private BeanDefinition createBeanDefinition(Class<?> clazz, Constructor<?> injectedConstructor) {
+        return new BeanDefinition(
+                clazz,
+                null,
+                (concreteObject, parameters) -> injectedConstructor.newInstance(parameters),
+                Arrays.asList(injectedConstructor.getParameterTypes())
+        );
+    }
+
+    private BeanDefinition createBeanDefinition(Class<?> clazz, Class<?> configClass, Method beanCreation) {
+        return new BeanDefinition(
+                clazz,
+                configClass,
+                beanCreation::invoke,
+                Arrays.asList(beanCreation.getParameterTypes())
+        );
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
@@ -19,18 +19,17 @@ public class BeanDefinitionFactory {
     private static final Logger logger = LoggerFactory.getLogger(BeanDefinitionFactory.class);
 
     private final Set<Class<?>> preInstantiateClasses;
+    private Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
 
     public BeanDefinitionFactory(Set<Class<?>> preInstantiateClasses) {
         this.preInstantiateClasses = preInstantiateClasses;
     }
 
     public Map<Class<?>, BeanDefinition> createBeanDefinition() {
-        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
-
         for (Class<?> preInstantiateClass : preInstantiateClasses) {
             Constructor<?> injectedConstructor = createInjectedConstructor(preInstantiateClass);
             definitions.put(preInstantiateClass, createBeanDefinition(preInstantiateClass, injectedConstructor));
-            createBeanDefinitionsOfConfiguration(definitions, preInstantiateClass);
+            createBeanDefinitionsOfConfiguration(preInstantiateClass);
         }
 
         return definitions;
@@ -52,12 +51,11 @@ public class BeanDefinitionFactory {
         }
     }
 
-    // TODO: 19. 11. 14. 메서드 매개변수로 선언된 definitions 리팩토링
-    private void createBeanDefinitionsOfConfiguration(Map<Class<?>, BeanDefinition> definitions, Class<?> clazz) {
+    private void createBeanDefinitionsOfConfiguration(Class<?> clazz) {
         if (clazz.isAnnotationPresent(Configuration.class)) {
             Method[] declaredMethods = clazz.getDeclaredMethods();
             List<Method> beanCreators = getBeanCreators(declaredMethods);
-            addBeanDefinition(definitions, beanCreators);
+            addBeanDefinition(beanCreators);
         }
     }
 
@@ -67,7 +65,7 @@ public class BeanDefinitionFactory {
                 .collect(Collectors.toList());
     }
 
-    private void addBeanDefinition(Map<Class<?>, BeanDefinition> definitions, List<Method> beanCreations) {
+    private void addBeanDefinition(List<Method> beanCreations) {
         for (Method beanCreation : beanCreations) {
             Class<?> beanType = beanCreation.getReturnType();
             Class<?> configType = beanCreation.getDeclaringClass();

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
@@ -1,93 +1,24 @@
 package nextstep.di.factory;
 
 import com.google.common.collect.Maps;
-import nextstep.annotation.Bean;
-import nextstep.annotation.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class BeanDefinitionFactory {
-    private static final Logger logger = LoggerFactory.getLogger(BeanDefinitionFactory.class);
 
-    private final Set<Class<?>> preInstantiateClasses;
-    private Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
+    public static Map<Class<?>, BeanDefinition> createBeanDefinitions(Set<Class<?>> preInstantiateClasses) {
+        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
 
-    public BeanDefinitionFactory(Set<Class<?>> preInstantiateClasses) {
-        this.preInstantiateClasses = preInstantiateClasses;
-    }
+        List<BeanDefinitionCreator> beanDefinitionCreators = Arrays.asList(new ClassBeanDefinitionCreator(),
+                new MethodBeanDefinitionCreator());
 
-    public Map<Class<?>, BeanDefinition> createBeanDefinition() {
-        for (Class<?> preInstantiateClass : preInstantiateClasses) {
-            Constructor<?> injectedConstructor = createInjectedConstructor(preInstantiateClass);
-            definitions.put(preInstantiateClass, createBeanDefinition(preInstantiateClass, injectedConstructor));
-            createBeanDefinitionsOfConfiguration(preInstantiateClass);
+        for (BeanDefinitionCreator beanDefinitionCreator : beanDefinitionCreators) {
+            definitions.putAll(beanDefinitionCreator.create(preInstantiateClasses));
         }
 
         return definitions;
-    }
-
-    private Constructor<?> createInjectedConstructor(Class concreteClass) {
-        Constructor<?> injectedConstructor = BeanFactoryUtils.getInjectedConstructor(concreteClass);
-
-        return injectedConstructor == null ? getDefaultConstructor(concreteClass) : injectedConstructor;
-    }
-
-    @SuppressWarnings("unchecked")
-    private Constructor getDefaultConstructor(Class concreteClass) {
-        try {
-            return concreteClass.getDeclaredConstructor();
-        } catch (NoSuchMethodException e) {
-            logger.error(e.getMessage(), e);
-            throw new BeanCreationFailException(e);
-        }
-    }
-
-    private void createBeanDefinitionsOfConfiguration(Class<?> clazz) {
-        if (clazz.isAnnotationPresent(Configuration.class)) {
-            Method[] declaredMethods = clazz.getDeclaredMethods();
-            List<Method> beanCreators = getBeanCreators(declaredMethods);
-            addBeanDefinition(beanCreators);
-        }
-    }
-
-    private List<Method> getBeanCreators(Method[] declaredMethods) {
-        return Stream.of(declaredMethods)
-                .filter(method -> method.isAnnotationPresent(Bean.class))
-                .collect(Collectors.toList());
-    }
-
-    private void addBeanDefinition(List<Method> beanCreations) {
-        for (Method beanCreation : beanCreations) {
-            Class<?> beanType = beanCreation.getReturnType();
-            Class<?> configType = beanCreation.getDeclaringClass();
-            definitions.put(beanType, createBeanDefinition(beanType, configType, beanCreation));
-        }
-    }
-
-    private BeanDefinition createBeanDefinition(Class<?> clazz, Constructor<?> injectedConstructor) {
-        return new BeanDefinition(
-                clazz,
-                null,
-                (concreteObject, parameters) -> injectedConstructor.newInstance(parameters),
-                Arrays.asList(injectedConstructor.getParameterTypes())
-        );
-    }
-
-    private BeanDefinition createBeanDefinition(Class<?> clazz, Class<?> configClass, Method beanCreation) {
-        return new BeanDefinition(
-                clazz,
-                configClass,
-                beanCreation::invoke,
-                Arrays.asList(beanCreation.getParameterTypes())
-        );
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
@@ -78,7 +78,7 @@ public class BeanFactory {
     private Object createConfigurationBean(Class<?> configType) {
         if (configType != null && beans.get(configType) == null) {
             BeanDefinition beanDefinition = definitions.get(configType);
-            beans.put(beanDefinition.getType(), createBean(beanDefinition));
+            return createBean(beanDefinition);
         }
 
         return beans.get(configType);

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
@@ -1,6 +1,7 @@
 package nextstep.di.factory;
 
 import com.google.common.collect.Maps;
+import nextstep.di.factory.exception.BeanCreationFailException;
 import nextstep.stereotype.Controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import nextstep.annotation.Inject;
 
 import java.lang.reflect.Constructor;
+import java.util.Map;
 import java.util.Set;
 
 import static org.reflections.ReflectionUtils.getAllConstructors;
@@ -52,5 +53,22 @@ public class BeanFactoryUtils {
         }
 
         throw new IllegalStateException(injectedClazz + "인터페이스를 구현하는 Bean이 존재하지 않는다.");
+    }
+
+    public static BeanDefinition findBeanDefinition(Class<?> clazz, Map<Class<?>, BeanDefinition> beanDefinitions) {
+        if (beanDefinitions.containsKey(clazz)) {
+            return beanDefinitions.get(clazz);
+        }
+
+        if (clazz.isInterface()) {
+            for (Class<?> beanDefinitionKey : beanDefinitions.keySet()) {
+                Set<Class<?>> interfaces = Sets.newHashSet(beanDefinitionKey.getInterfaces());
+                if (interfaces.contains(clazz)) {
+                    return beanDefinitions.get(beanDefinitionKey);
+                }
+            }
+        }
+
+        throw new IllegalStateException(clazz + "인터페이스를 구현하는 Bean이 존재하지 않는다.");
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
@@ -2,6 +2,7 @@ package nextstep.di.factory;
 
 import com.google.common.collect.Sets;
 import nextstep.annotation.Inject;
+import nextstep.di.factory.exception.DoesNotAllowMultipleInjectedConstructorException;
 
 import java.lang.reflect.Constructor;
 import java.util.Map;

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
@@ -11,6 +11,22 @@ import static org.reflections.ReflectionUtils.getAllConstructors;
 import static org.reflections.ReflectionUtils.withAnnotation;
 
 public class BeanFactoryUtils {
+
+    /**
+     * 인자로 전달하는 클래스의 생성자 중 @Inject 애노테이션이 설정되어 있는 생성자를 반환
+     *
+     * @param clazz
+     * @return
+     * @Inject 애노테이션이 설정되어 있는 생성자는 클래스당 하나로 가정한다.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static Set<Constructor> getInjectedConstructors(Class<?> clazz) {
+        Set<Constructor> injectedConstructors = getAllConstructors(clazz, withAnnotation(Inject.class));
+        validateMultipleInjectedConstructor(injectedConstructors);
+
+        return injectedConstructors;
+    }
+
     /**
      * 인자로 전달하는 클래스의 생성자 중 @Inject 애노테이션이 설정되어 있는 생성자를 반환
      *

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -18,22 +18,6 @@ public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scan(String basePackage) {
-        Reflections reflections = new Reflections(basePackage);
-        return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation>... annotations) {
-        Set<Class<?>> beans = Sets.newHashSet();
-        for (Class<? extends Annotation> annotation : annotations) {
-            beans.addAll(reflections.getTypesAnnotatedWith(annotation));
-        }
-        log.debug("Scan Beans Type : {}", beans);
-        return beans;
-    }
-
-    @SuppressWarnings("unchecked")
     public static Set<Class<?>> scanConfiguration(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
 
@@ -52,5 +36,21 @@ public class BeanScanner {
 
         scannedComponents.addAll(configurations);
         return scannedComponents;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Set<Class<?>> scan(String basePackage) {
+        Reflections reflections = new Reflections(basePackage);
+        return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class, Configuration.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation>... annotations) {
+        Set<Class<?>> beans = Sets.newHashSet();
+        for (Class<? extends Annotation> annotation : annotations) {
+            beans.addAll(reflections.getTypesAnnotatedWith(annotation));
+        }
+        log.debug("Scan Beans Type : {}", beans);
+        return beans;
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -18,7 +18,7 @@ public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scanConfiguration(String basePackage) {
+    public static Set<Class<?>> scan(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
 
         Set<Class<?>> scannedComponents = Sets.newHashSet();
@@ -29,8 +29,9 @@ public class BeanScanner {
 
             if (componentScan != null) {
                 Stream.of(componentScan.value())
-                        .map(BeanScanner::scan)
-                        .forEach(scannedComponents::addAll);
+                        .map(BeanScanner::scanAnnotation)
+                        .forEach(scannedComponents::addAll)
+                ;
             }
         }
 
@@ -39,7 +40,7 @@ public class BeanScanner {
     }
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scan(String basePackage) {
+    private static Set<Class<?>> scanAnnotation(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
         return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class, Configuration.class);
     }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -1,6 +1,8 @@
 package nextstep.di.factory;
 
 import com.google.common.collect.Sets;
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
 import nextstep.stereotype.Controller;
 import nextstep.stereotype.Repository;
 import nextstep.stereotype.Service;
@@ -10,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
@@ -28,5 +31,26 @@ public class BeanScanner {
         }
         log.debug("Scan Beans Type : {}", beans);
         return beans;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Set<Class<?>> scanConfiguration(String basePackage) {
+        Reflections reflections = new Reflections(basePackage);
+
+        Set<Class<?>> scannedComponents = Sets.newHashSet();
+        Set<Class<?>> configurations = getTypesAnnotatedWith(reflections, Configuration.class);
+
+        for (Class<?> configuration : configurations) {
+            ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
+
+            if (componentScan != null) {
+                Stream.of(componentScan.value())
+                        .map(BeanScanner::scan)
+                        .forEach(scannedComponents::addAll);
+            }
+        }
+
+        scannedComponents.addAll(configurations);
+        return scannedComponents;
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -18,29 +18,30 @@ public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scan(String basePackage) {
+    public static Set<Class<?>> scanConfiguration(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
-
-        Set<Class<?>> scannedComponents = Sets.newHashSet();
         Set<Class<?>> configurations = getTypesAnnotatedWith(reflections, Configuration.class);
-
-        for (Class<?> configuration : configurations) {
-            ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
-
-            if (componentScan != null) {
-                Stream.of(componentScan.value())
-                        .map(BeanScanner::scanAnnotation)
-                        .forEach(scannedComponents::addAll)
-                ;
-            }
-        }
+        Set<Class<?>> scannedComponents = Sets.newHashSet();
 
         scannedComponents.addAll(configurations);
+        scannedComponents.addAll(scanComponentsInBasePackagesOf(configurations));
         return scannedComponents;
     }
 
+    private static Set<Class<?>> scanComponentsInBasePackagesOf(Set<Class<?>> configurations) {
+        Set<Class<?>> components = Sets.newHashSet();
+
+        configurations.stream()
+                .filter(configuration -> configuration.isAnnotationPresent(ComponentScan.class))
+                .map(configuration -> configuration.getAnnotation(ComponentScan.class))
+                .flatMap(componentScan -> Stream.of(componentScan.value()))
+                .map(BeanScanner::scanComponents)
+                .forEach(components::addAll);
+        return components;
+    }
+
     @SuppressWarnings("unchecked")
-    private static Set<Class<?>> scanAnnotation(String basePackage) {
+    private static Set<Class<?>> scanComponents(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
         return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class, Configuration.class);
     }

--- a/nextstep-di/src/main/java/nextstep/di/factory/ClassBeanDefinitionCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/ClassBeanDefinitionCreator.java
@@ -1,6 +1,7 @@
 package nextstep.di.factory;
 
 import com.google.common.collect.Maps;
+import nextstep.di.factory.exception.BeanCreationFailException;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;

--- a/nextstep-di/src/main/java/nextstep/di/factory/ClassBeanDefinitionCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/ClassBeanDefinitionCreator.java
@@ -1,0 +1,50 @@
+package nextstep.di.factory;
+
+import com.google.common.collect.Maps;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+public class ClassBeanDefinitionCreator implements BeanDefinitionCreator {
+
+    @Override
+    public Map<Class<?>, BeanDefinition> create(Set<Class<?>> preInstantiateClasses) {
+        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
+
+        for (Class<?> clazz : preInstantiateClasses) {
+            BeanDefinition definition = createBeanDefinition(clazz);
+            definitions.put(clazz, definition);
+        }
+
+        return definitions;
+    }
+
+    private BeanDefinition createBeanDefinition(Class<?> clazz) {
+        Constructor<?> injectedConstructor = createInjectedConstructor(clazz);
+
+        return new BeanDefinition(
+                clazz,
+                null,
+                (concreteObject, parameters) -> injectedConstructor.newInstance(parameters),
+                Arrays.asList(injectedConstructor.getParameterTypes())
+        );
+    }
+
+    private Constructor<?> createInjectedConstructor(Class concreteClass) {
+        Set<Constructor> injectedConstructor = BeanFactoryUtils.getInjectedConstructors(concreteClass);
+        return injectedConstructor.isEmpty()
+                ? getDefaultConstructor(concreteClass)
+                : injectedConstructor.iterator().next();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor getDefaultConstructor(Class concreteClass) {
+        try {
+            return concreteClass.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            throw new BeanCreationFailException(e);
+        }
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/MethodBeanDefinitionCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/MethodBeanDefinitionCreator.java
@@ -1,0 +1,56 @@
+package nextstep.di.factory;
+
+import com.google.common.collect.Maps;
+import nextstep.annotation.Bean;
+import nextstep.annotation.Configuration;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MethodBeanDefinitionCreator implements BeanDefinitionCreator {
+
+    @Override
+    public Map<Class<?>, BeanDefinition> create(Set<Class<?>> preInstantiateClasses) {
+        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
+
+        preInstantiateClasses.stream()
+                .filter(clazz -> clazz.isAnnotationPresent(Configuration.class))
+                .forEach(configuration -> saveAllBeanDefinitions(configuration, definitions));
+
+        return definitions;
+    }
+
+    private void saveAllBeanDefinitions(Class<?> configuration, Map<Class<?>, BeanDefinition> definitions) {
+        List<Method> beanCreators = getBeanCreators(configuration);
+
+        for (Method beanCreator : beanCreators) {
+            Class<?> beanType = beanCreator.getReturnType();
+            definitions.put(beanType, createBeanDefinition(beanCreator));
+        }
+    }
+
+    private List<Method> getBeanCreators(Class<?> configuration) {
+        Method[] declaredMethods = configuration.getDeclaredMethods();
+
+        return Stream.of(declaredMethods)
+                .filter(method -> method.isAnnotationPresent(Bean.class))
+                .collect(Collectors.toList());
+    }
+
+    private BeanDefinition createBeanDefinition(Method beanCreator) {
+        Class<?> clazz = beanCreator.getReturnType();
+        Class<?> configType = beanCreator.getDeclaringClass();
+
+        return new BeanDefinition(
+                clazz,
+                configType,
+                beanCreator::invoke,
+                Arrays.asList(beanCreator.getParameterTypes())
+        );
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/exception/BeanCreationFailException.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/exception/BeanCreationFailException.java
@@ -1,4 +1,4 @@
-package nextstep.di.factory;
+package nextstep.di.factory.exception;
 
 public class BeanCreationFailException extends RuntimeException {
     private static final String MESSAGE = "빈 생성에 실패했습니다.";

--- a/nextstep-di/src/main/java/nextstep/di/factory/exception/DoesNotAllowMultipleInjectedConstructorException.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/exception/DoesNotAllowMultipleInjectedConstructorException.java
@@ -1,4 +1,4 @@
-package nextstep.di.factory;
+package nextstep.di.factory.exception;
 
 public class DoesNotAllowMultipleInjectedConstructorException extends RuntimeException {
     private static final String MESSAGE = "Inject 애너테이션은 하나의 생성자에만 선언할 수 있습니다.";

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
@@ -1,0 +1,54 @@
+package nextstep.di.factory;
+
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.controller.QnaController;
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class BeanDefinitionFactoryTest {
+    @Test
+    @DisplayName("Scan한 클래스로부터 BeanDefinition을 생성한다.")
+    void createBeanDefinition() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(ExampleConfig.class, QnaController.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        assertNotNull(beanDefinitions.get(ExampleConfig.class));
+        assertNotNull(beanDefinitions.get(QnaController.class));
+        assertNotNull(beanDefinitions.get(DataSource.class));
+    }
+
+    @Test
+    @DisplayName("Bean이 Configuration을 통해 생성되는 경우, 생성된 BeanDefinition의 configType은 해당 Configuration 클래스다.")
+    void checkConfigType_ifBeanIsGeneratedByConfiguration() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(ExampleConfig.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        BeanDefinition dataSourceBeanDefinition = beanDefinitions.get(DataSource.class);
+        assertThat(dataSourceBeanDefinition.getConfigType()).isEqualTo(ExampleConfig.class);
+    }
+
+    @Test
+    @DisplayName("Configuration에서 생성하는 bean이 아닌 경우, BeanDefinition의 configType은 null이다.")
+    void createBeanDefinitio() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(QnaController.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        BeanDefinition qnaControllerBeanDefinition = beanDefinitions.get(QnaController.class);
+        assertNull(qnaControllerBeanDefinition.getConfigType());
+    }
+
+    private Map<Class<?>, BeanDefinition> createBeanDefinitions(Set<Class<?>> preInstantiateClazz) {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
+        return beanDefinitionFactory.createBeanDefinition();
+    }
+}

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
@@ -48,7 +48,6 @@ public class BeanDefinitionFactoryTest {
     }
 
     private Map<Class<?>, BeanDefinition> createBeanDefinitions(Set<Class<?>> preInstantiateClazz) {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
-        return beanDefinitionFactory.createBeanDefinition();
+        return BeanDefinitionFactory.createBeanDefinitions(preInstantiateClazz);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -21,7 +21,7 @@ class BeanFactoryTest {
 
     @BeforeEach
     void setup() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
         BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
         beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
         beanFactory.initialize();

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -1,12 +1,16 @@
 package nextstep.di.factory;
 
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.config.IntegrationConfig;
 import nextstep.di.factory.example.controller.QnaController;
+import nextstep.di.factory.example.repository.MyJdbcTemplate;
 import nextstep.di.factory.example.service.MyQnaService;
 import nextstep.di.factory.example.service.TestService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,8 +21,9 @@ class BeanFactoryTest {
 
     @BeforeEach
     void setup() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
-        beanFactory = new BeanFactory(preInstantiateClazz);
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
+        beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
         beanFactory.initialize();
     }
 
@@ -41,5 +46,17 @@ class BeanFactoryTest {
 
         assertNotNull(testService);
         assertNotNull(testService.getMyQnaService());
+    }
+
+    @Test
+    @DisplayName("Configuration 클래스를 통해 bean을 등록한다.")
+    void beanCreationByConfiguration() {
+        assertNotNull(beanFactory.getBean(DataSource.class));
+        assertNotNull(beanFactory.getBean(ExampleConfig.class));
+
+        assertNotNull(beanFactory.getBean(IntegrationConfig.class));
+        assertNotNull(beanFactory.getBean(DataSource.class));
+        assertNotNull(beanFactory.getBean(MyJdbcTemplate.class));
+
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -22,8 +22,7 @@ class BeanFactoryTest {
     @BeforeEach
     void setup() {
         Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
-        BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
-        beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
+        beanFactory = new BeanFactory(BeanDefinitionFactory.createBeanDefinitions(preInstantiateClazz));
         beanFactory.initialize();
     }
 

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -21,7 +21,7 @@ class BeanFactoryTest {
 
     @BeforeEach
     void setup() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
         BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
         beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
         beanFactory.initialize();

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -44,7 +44,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfInterface() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
@@ -54,7 +54,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfClass() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
@@ -64,7 +64,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
     void failToFindDefinition() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -5,6 +5,7 @@ import nextstep.di.factory.example.repository.JdbcQuestionRepository;
 import nextstep.di.factory.example.repository.JdbcUserRepository;
 import nextstep.di.factory.example.repository.UserRepository;
 import nextstep.di.factory.example.service.MyQnaService;
+import nextstep.di.factory.exception.DoesNotAllowMultipleInjectedConstructorException;
 import nextstep.di.factory.outside.MultipleInjectedService;
 import nextstep.di.factory.outside.OutsideService;
 import org.junit.jupiter.api.DisplayName;

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -2,12 +2,16 @@ package nextstep.di.factory;
 
 import nextstep.di.factory.example.controller.QnaController;
 import nextstep.di.factory.example.repository.JdbcQuestionRepository;
+import nextstep.di.factory.example.repository.JdbcUserRepository;
+import nextstep.di.factory.example.repository.UserRepository;
 import nextstep.di.factory.example.service.MyQnaService;
 import nextstep.di.factory.outside.MultipleInjectedService;
+import nextstep.di.factory.outside.OutsideService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,5 +39,35 @@ class BeanFactoryUtilsTest {
     @DisplayName("@Inject 애너테이션이 없는 경우에는 null을 반환한다.")
     void getInjectedConstructor_IfInjectedConstructorIsEmpty_returnNull() {
         assertNull(BeanFactoryUtils.getInjectedConstructor(JdbcQuestionRepository.class));
+    }
+
+    @Test
+    @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
+    void findConcreteDefinitionOfInterface() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
+        assertThat(beanDefinition.getType()).isEqualTo(JdbcUserRepository.class);
+    }
+
+    @Test
+    @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
+    void findConcreteDefinitionOfClass() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
+        assertThat(beanDefinition.getType()).isEqualTo(MyQnaService.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
+    void failToFindDefinition() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -44,7 +44,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfInterface() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
@@ -54,7 +54,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfClass() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
@@ -64,7 +64,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
     void failToFindDefinition() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -12,18 +12,20 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class BeanFactoryUtilsTest {
+
     @Test
     @DisplayName("@Inject 애너테이션이 선언된 생성자를 반환한다.")
     void getInjectedConstructor() {
-        Constructor<?> constructor = BeanFactoryUtils.getInjectedConstructor(QnaController.class);
-        Class<?>[] parameterTypes = constructor.getParameterTypes();
+        Set<Constructor> constructor = BeanFactoryUtils.getInjectedConstructors(QnaController.class);
+        Class<?>[] parameterTypes = constructor.iterator().next().getParameterTypes();
 
+        assertThat(constructor.size()).isEqualTo(1);
         assertThat(parameterTypes.length).isEqualTo(1);
         assertThat(parameterTypes).contains(MyQnaService.class);
     }
@@ -31,21 +33,21 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("@Inject 애너테이션이 여러개 선언 된 클래스인 경우 예외를 반환한다.")
     void getInjectedConstructor_amongManyInjectedConstructors_returnFirstConstructor() {
-        assertThatThrownBy(() -> BeanFactoryUtils.getInjectedConstructor(MultipleInjectedService.class))
+        assertThatThrownBy(() -> BeanFactoryUtils.getInjectedConstructors(MultipleInjectedService.class))
                 .isInstanceOf(DoesNotAllowMultipleInjectedConstructorException.class);
     }
 
     @Test
     @DisplayName("@Inject 애너테이션이 없는 경우에는 null을 반환한다.")
     void getInjectedConstructor_IfInjectedConstructorIsEmpty_returnNull() {
-        assertNull(BeanFactoryUtils.getInjectedConstructor(JdbcQuestionRepository.class));
+        Set<Constructor> injectedConstructors = BeanFactoryUtils.getInjectedConstructors(JdbcQuestionRepository.class);
+        assertThat(injectedConstructors).isEmpty();
     }
 
     @Test
     @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfInterface() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
-        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+        Map<Class<?>, BeanDefinition> definitions = BeanDefinitionFactory.createBeanDefinitions(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
         assertThat(beanDefinition.getType()).isEqualTo(JdbcUserRepository.class);
@@ -54,8 +56,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfClass() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
-        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+        Map<Class<?>, BeanDefinition> definitions = BeanDefinitionFactory.createBeanDefinitions(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
         assertThat(beanDefinition.getType()).isEqualTo(MyQnaService.class);
@@ -64,8 +65,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
     void failToFindDefinition() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
-        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+        Map<Class<?>, BeanDefinition> definitions = BeanDefinitionFactory.createBeanDefinitions(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
 
         assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))
                 .isInstanceOf(IllegalStateException.class);

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -21,44 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BeanScannerTest {
 
     @Test
-    @DisplayName("scan메서드에 패키지명을 넣어주면 해당 패키지의 @Controller, @Service, @Repository 구현 클래스를 스캔한다.")
-    void scanAll() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
-
-        assertThat(preInstantiateClazz).contains(
-                QnaController.class,
-                MyQnaService.class,
-                TestService.class,
-                JdbcQuestionRepository.class,
-                JdbcUserRepository.class
-        );
-        assertThat(preInstantiateClazz.size()).isEqualTo(5);
-    }
-
-    @Test
-    @DisplayName("scan 메서드에 해당하는 패키지와 하위 패키지 이외의 클래스는 스캔하지 않는다.")
-    void notScanOutsideOfPackage() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
-
-        assertThat(preInstantiateClazz).doesNotContain(
-                OutsideController.class,
-                OutsideService.class,
-                OutsideRepository.class
-        );
-    }
-
-    @Test
-    @DisplayName("@Controller, @Service, @Repository 이외의 애노테이션이 선언된 클래스는 스캔하지 않는다.")
-    void ignoreInvalidAnnotation() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
-
-        assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
-    }
-
-    @Test
     @DisplayName("빈 설정 파일을 스캔한다.")
     void configurationScan() {
-        Set<Class<?>> configurations = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        Set<Class<?>> configurations = BeanScanner.scan("nextstep.di.factory.example.config");
 
         assertThat(configurations).contains(
                 ExampleConfig.class,
@@ -70,5 +35,25 @@ public class BeanScannerTest {
                 JdbcUserRepository.class
         );
         assertThat(configurations.size()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("scan 메서드에 해당하는 패키지와 하위 패키지 이외의 클래스는 스캔하지 않는다.")
+    void notScanOutsideOfPackage() {
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
+
+        assertThat(preInstantiateClazz).doesNotContain(
+                OutsideController.class,
+                OutsideService.class,
+                OutsideRepository.class
+        );
+    }
+
+    @Test
+    @DisplayName("@Controller, @Service, @Repository 이외의 애노테이션이 선언된 클래스는 스캔하지 않는다.")
+    void ignoreInvalidAnnotation() {
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
+
+        assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -1,6 +1,8 @@
 package nextstep.di.factory;
 
 import nextstep.di.factory.example.TestApplication;
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.config.IntegrationConfig;
 import nextstep.di.factory.example.controller.QnaController;
 import nextstep.di.factory.example.repository.JdbcQuestionRepository;
 import nextstep.di.factory.example.repository.JdbcUserRepository;
@@ -51,5 +53,22 @@ public class BeanScannerTest {
         Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
+    }
+
+    @Test
+    @DisplayName("빈 설정 파일을 스캔한다.")
+    void configurationScan() {
+        Set<Class<?>> configurations = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+
+        assertThat(configurations).contains(
+                ExampleConfig.class,
+                IntegrationConfig.class,
+                QnaController.class,
+                MyQnaService.class,
+                TestService.class,
+                JdbcQuestionRepository.class,
+                JdbcUserRepository.class
+        );
+        assertThat(configurations.size()).isEqualTo(7);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -23,7 +23,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("빈 설정 파일을 스캔한다.")
     void configurationScan() {
-        Set<Class<?>> configurations = BeanScanner.scan("nextstep.di.factory.example.config");
+        Set<Class<?>> configurations = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
 
         assertThat(configurations).contains(
                 ExampleConfig.class,
@@ -40,7 +40,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("scan 메서드에 해당하는 패키지와 하위 패키지 이외의 클래스는 스캔하지 않는다.")
     void notScanOutsideOfPackage() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
 
         assertThat(preInstantiateClazz).doesNotContain(
                 OutsideController.class,
@@ -52,7 +52,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("@Controller, @Service, @Repository 이외의 애노테이션이 선언된 클래스는 스캔하지 않는다.")
     void ignoreInvalidAnnotation() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
 
         assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
     }

--- a/nextstep-di/src/test/java/nextstep/di/factory/example/config/ExampleConfig.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/example/config/ExampleConfig.java
@@ -1,12 +1,14 @@
 package nextstep.di.factory.example.config;
 
 import nextstep.annotation.Bean;
+import nextstep.annotation.ComponentScan;
 import nextstep.annotation.Configuration;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 import javax.sql.DataSource;
 
 @Configuration
+@ComponentScan("nextstep.di.factory.example")
 public class ExampleConfig {
     @Bean
     public DataSource dataSource() {

--- a/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -17,7 +17,7 @@ public class AnnotationHandlerMappingTest {
 
     @BeforeEach
     public void setup() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("samples"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("samples"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
 
         beanFactory.initialize();

--- a/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -1,6 +1,7 @@
 package nextstep.mvc.tobe;
 
 import nextstep.db.DataBase;
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +17,9 @@ public class AnnotationHandlerMappingTest {
 
     @BeforeEach
     public void setup() {
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("samples"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("samples"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
+
         beanFactory.initialize();
         handlerMapping = new AnnotationHandlerMapping(beanFactory);
 

--- a/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -17,7 +17,7 @@ public class AnnotationHandlerMappingTest {
 
     @BeforeEach
     public void setup() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("samples"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("samples"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
 
         beanFactory.initialize();

--- a/nextstep-mvc/src/test/java/samples/SampleApplication.java
+++ b/nextstep-mvc/src/test/java/samples/SampleApplication.java
@@ -1,0 +1,9 @@
+package samples;
+
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
+
+@Configuration
+@ComponentScan("samples")
+public class SampleApplication {
+}

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -1,5 +1,6 @@
 package slipp;
 
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import nextstep.mvc.DispatcherServlet;
@@ -19,7 +20,8 @@ public class SlippWebApplicationInitializer  implements WebApplicationInitialize
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 
         DispatcherServlet dispatcherServlet = new DispatcherServlet();

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -20,7 +20,7 @@ public class SlippWebApplicationInitializer  implements WebApplicationInitialize
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -20,7 +20,7 @@ public class SlippWebApplicationInitializer  implements WebApplicationInitialize
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -14,14 +14,15 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
+import java.util.Set;
 
 public class SlippWebApplicationInitializer  implements WebApplicationInitializer {
     private static final Logger log = LoggerFactory.getLogger(SlippWebApplicationInitializer.class);
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
-        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
+        Set<Class<?>> preInstantiateClasses = BeanScanner.scanConfiguration("slipp");
+        BeanFactory beanFactory = new BeanFactory(BeanDefinitionFactory.createBeanDefinitions(preInstantiateClasses));
         beanFactory.initialize();
 
         DispatcherServlet dispatcherServlet = new DispatcherServlet();

--- a/slipp/src/main/java/slipp/support/config/MyConfiguration.java
+++ b/slipp/src/main/java/slipp/support/config/MyConfiguration.java
@@ -1,0 +1,23 @@
+package slipp.support.config;
+
+import nextstep.annotation.Bean;
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
+import org.apache.commons.dbcp2.BasicDataSource;
+
+import javax.sql.DataSource;
+
+@Configuration
+@ComponentScan({ "next", "core" })
+public class MyConfiguration {
+
+    @Bean
+    public DataSource dataSource() {
+        BasicDataSource ds = new BasicDataSource();
+        ds.setDriverClassName("org.h2.Driver");
+        ds.setUrl("jdbc:h2:~/jwp-framework;MVCC=TRUE;DB_CLOSE_ON_EXIT=FALSE");
+        ds.setUsername("sa");
+        ds.setPassword("");
+        return ds;
+    }
+}

--- a/slipp/src/test/java/slipp/DispatcherServletTest.java
+++ b/slipp/src/test/java/slipp/DispatcherServletTest.java
@@ -1,5 +1,6 @@
 package slipp;
 
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import nextstep.jdbc.ConnectionManager;
@@ -30,7 +31,8 @@ class DispatcherServletTest {
         populator.addScript(new ClassPathResource("jwp.sql"));
         DatabasePopulatorUtils.execute(populator, ConnectionManager.getDataSource());
 
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 
         dispatcher = new DispatcherServlet();

--- a/slipp/src/test/java/slipp/DispatcherServletTest.java
+++ b/slipp/src/test/java/slipp/DispatcherServletTest.java
@@ -31,7 +31,7 @@ class DispatcherServletTest {
         populator.addScript(new ClassPathResource("jwp.sql"));
         DatabasePopulatorUtils.execute(populator, ConnectionManager.getDataSource());
 
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 

--- a/slipp/src/test/java/slipp/DispatcherServletTest.java
+++ b/slipp/src/test/java/slipp/DispatcherServletTest.java
@@ -31,7 +31,7 @@ class DispatcherServletTest {
         populator.addScript(new ClassPathResource("jwp.sql"));
         DatabasePopulatorUtils.execute(populator, ConnectionManager.getDataSource());
 
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 


### PR DESCRIPTION
안녕하세요 브리!
먼저 step1에서 피드백 주신 부분에 대해서 말씀드리겠습니다.

> 빈 생성(createBean()) 시 이미 존재하는 인스턴스인지 확인을 하는 로직이 있는데,
> 인스턴스를 중복으로 만들 것으로 예상되는 부분이나 상황이 어디일까요?

이 부분은 현재 step2 코드에도 똑같이 중복이 발생한다고 생각합니다. 빈을 만들 때 `createBean()` 재귀 함수가 끝나고 난 후에 실제적으로 `beans`에 등록하고 있습니다. 따라서 클래스 A를 빈으로 만들 때 생성자로 아직 빈으로 등록되지 않은 클래스 B, C가 필요하다고 하면, 클래스 A를 빈으로 등록하는 재귀 함수 중간에 클래스 B, C 역시 인스턴스화를 수행하지만 이를 `beans`에 등록하지 않고, List `parameter`에 저장한 후 이를 매개변수로 넘겨주어 클래스 A를 인스턴스화하고 있습니다. 그 결과 `initialize()` 메서드의 for문에서 클래스 A 다음 B, C 순서로 동작한다면 클래스 B, C는 아직 `beans`에 등록되어 있지 않으므로 한 번 더 인스턴스화한 후 빈으로 등록될 것이라 생각하였습니다.

---

Step2를 구현하면서 `@Configuration` 어노테이션이 붙은 클래스 내부의 `@Bean` 어노테이션이 선언된 메서드를 빈으로 등록할 때, 다른 컴포넌트(`@Controller`, `@Service` 등 어노테이션으로 선언된 클래스)와의 의존성을 고려하는 것이 어려웠습니다. 현재는 다음과 같은 과정으로 빈을 등록하고 있습니다.
- BasePackage는 `@Configuration`이 선언된 클래스에서 `@ComponentScan`의 `value`값으로 선언된 경로로 컴포넌트들을 찾고 있습니다.
- `BeanScanner`는 `@ComponentScan`으로 선언된 BasePackage 경로의 컴포넌트와 `@Configuration`이 선언된 클래스들의 클래스 타입을 스캔합니다.
- `BeanDefinitionFactory`는 `BeanScanner`를 통해 스캔된 클래스들의 `BeanDefinition`을 생성합니다. `BeanDefinition`은 해당 클래스 타입과 생성 방법 등을 저장하고 있습니다. 그리고 이 팩토리에서 `@Configuration` 클래스의 `BeanDefinition`뿐 아니라 내부의 `@Bean`으로 선언된 메서드를 빈으로 등록하기 위한 `BeanDefinition`도 저장하고 있습니다.
- `BeanFactory`는 위에서 만들어진 `BeanDefinition`을 가지고 빈을 생성하여 `beans`에 등록합니다.

빈을 생성하면서 발생할 수 있는 여러 의존성을 생각하여 빈으로 등록할 수 있는 모든 클래스에 대해 `BeanDefinition`을 만들고, 이를 사용하여 한 번의 재귀함수를 통해 빈으로 등록되도록 구현하였습니다.

---

구현하면서 한 가지 의문사항이 있어 질문드리겠습니다.
- `@ComponentScan` 어노테이션에 value와 basepackage가 공통된 정보를 나타내서 이를 어떻게 처리해야할지 궁금합니다. (현재는 `value` 하나만을 사용하고 있습니다.) 

부족하지만 잘 부탁드립니다! 감사합니다!
