### PR TITLE
[DI - step2] 철시 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 3. 드라이버는 30분 간격으로 교체한다.
 4. TDD로 할 수 있다면 최대한 적용한다.
 
-## 요구사항
+## step-1 요구사항
 
 - @Service, @Repository 클래스 스캔
     
@@ -17,11 +17,12 @@
 - @Inject에 필요한 객체를 찾아서 주입 / 생성
 - 기존의 @Controller를 스캔하는 ControllerScanner 클래스를 확장된 BeanScanner와 통합
 
-## TO DO
-- `BeanFactoryUtils.getInjectedConstructor` 메서드에서 `@Inject`가 붙은 생성자가 여러개일 때 처리 방법 고민 
--  BeanScannerTest 추가
-    - base 패키지 바깥의 클래스를 스캔하지 않는지 확인
-    - 다른 종류의 애노테이션이 선언된 클래스를 스캔하지 않는지 확인
+## step-2 요구사항
+
+- @Configuration 어노테이션으로 빈 설정
     
- ## 의문 사항
- - 테스트 코드를 작성하면서 테스트만을 위한 패키지를 만드는 것에 대해 어떻게 생각하시나요?
+    1. @ComponentScan
+    2. @Bean으로 빈 수동 생성
+    
+    @Configuration을 찾고 @ComponentScan의 값을 BeanScanner에 전달하여 빈 생성
+    @Configuration도 빈으로 등록하여 내부의 @Bean 메서드 결과를 빈으로 등록한다.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@
     
     @Configuration을 찾고 @ComponentScan의 값을 BeanScanner에 전달하여 빈 생성
     @Configuration도 빈으로 등록하여 내부의 @Bean 메서드 결과를 빈으로 등록한다.
+
+
+### 의문사항
+- `@ComponentScan` 어노테이션에 value와 basepackage가 공통된 정보를 나타내서 이를 어떻게 처리해야할지 궁금합니다.

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanCreator.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanCreator.java
@@ -1,0 +1,9 @@
+package nextstep.di.factory;
+
+import java.lang.reflect.InvocationTargetException;
+
+@FunctionalInterface
+public interface BeanCreator {
+
+    Object create(Object concreteObject, Object... objects) throws IllegalAccessException, InvocationTargetException, InstantiationException;
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinition.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinition.java
@@ -1,0 +1,33 @@
+package nextstep.di.factory;
+
+import java.util.List;
+
+public class BeanDefinition {
+    private Class<?> type;
+    private Class<?> configType;
+    private BeanCreator beanCreator;
+    private List<Class<?>> parameters;
+
+    public BeanDefinition(Class<?> type, Class<?> configType, BeanCreator beanCreator, List<Class<?>> parameters) {
+        this.type = type;
+        this.configType = configType;
+        this.beanCreator = beanCreator;
+        this.parameters = parameters;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public Class<?> getConfigType() {
+        return configType;
+    }
+
+    public BeanCreator getBeanCreator() {
+        return beanCreator;
+    }
+
+    public List<Class<?>> getParameters() {
+        return parameters;
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
@@ -1,0 +1,95 @@
+package nextstep.di.factory;
+
+import com.google.common.collect.Maps;
+import nextstep.annotation.Bean;
+import nextstep.annotation.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BeanDefinitionFactory {
+    private static final Logger logger = LoggerFactory.getLogger(BeanDefinitionFactory.class);
+
+    private final Set<Class<?>> preInstantiateClasses;
+
+    public BeanDefinitionFactory(Set<Class<?>> preInstantiateClasses) {
+        this.preInstantiateClasses = preInstantiateClasses;
+    }
+
+    public Map<Class<?>, BeanDefinition> createBeanDefinition() {
+        Map<Class<?>, BeanDefinition> definitions = Maps.newHashMap();
+
+        for (Class<?> preInstantiateClass : preInstantiateClasses) {
+            Constructor<?> injectedConstructor = createInjectedConstructor(preInstantiateClass);
+            definitions.put(preInstantiateClass, createBeanDefinition(preInstantiateClass, injectedConstructor));
+            createBeanDefinitionsOfConfiguration(definitions, preInstantiateClass);
+        }
+
+        return definitions;
+    }
+
+    private Constructor<?> createInjectedConstructor(Class concreteClass) {
+        Constructor<?> injectedConstructor = BeanFactoryUtils.getInjectedConstructor(concreteClass);
+
+        return injectedConstructor == null ? getDefaultConstructor(concreteClass) : injectedConstructor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Constructor getDefaultConstructor(Class concreteClass) {
+        try {
+            return concreteClass.getDeclaredConstructor();
+        } catch (NoSuchMethodException e) {
+            logger.error(e.getMessage(), e);
+            throw new BeanCreationFailException(e);
+        }
+    }
+
+    // TODO: 19. 11. 14. 메서드 매개변수로 선언된 definitions 리팩토링
+    private void createBeanDefinitionsOfConfiguration(Map<Class<?>, BeanDefinition> definitions, Class<?> clazz) {
+        if (clazz.isAnnotationPresent(Configuration.class)) {
+            Method[] declaredMethods = clazz.getDeclaredMethods();
+            List<Method> beanCreators = getBeanCreators(declaredMethods);
+            addBeanDefinition(definitions, beanCreators);
+        }
+    }
+
+    private List<Method> getBeanCreators(Method[] declaredMethods) {
+        return Stream.of(declaredMethods)
+                .filter(method -> method.isAnnotationPresent(Bean.class))
+                .collect(Collectors.toList());
+    }
+
+    private void addBeanDefinition(Map<Class<?>, BeanDefinition> definitions, List<Method> beanCreations) {
+        for (Method beanCreation : beanCreations) {
+            Class<?> beanType = beanCreation.getReturnType();
+            Class<?> configType = beanCreation.getDeclaringClass();
+            definitions.put(beanType, createBeanDefinition(beanType, configType, beanCreation));
+        }
+    }
+
+    private BeanDefinition createBeanDefinition(Class<?> clazz, Constructor<?> injectedConstructor) {
+        return new BeanDefinition(
+                clazz,
+                null,
+                (concreteObject, parameters) -> injectedConstructor.newInstance(parameters),
+                Arrays.asList(injectedConstructor.getParameterTypes())
+        );
+    }
+
+    private BeanDefinition createBeanDefinition(Class<?> clazz, Class<?> configClass, Method beanCreation) {
+        return new BeanDefinition(
+                clazz,
+                configClass,
+                beanCreation::invoke,
+                Arrays.asList(beanCreation.getParameterTypes())
+        );
+    }
+}

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanDefinitionFactory.java
@@ -52,7 +52,6 @@ public class BeanDefinitionFactory {
         }
     }
 
-    // TODO: 19. 11. 14. 메서드 매개변수로 선언된 definitions 리팩토링
     private void createBeanDefinitionsOfConfiguration(Map<Class<?>, BeanDefinition> definitions, Class<?> clazz) {
         if (clazz.isAnnotationPresent(Configuration.class)) {
             Method[] declaredMethods = clazz.getDeclaredMethods();

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactory.java
@@ -37,19 +37,17 @@ public class BeanFactory {
 
     public void initialize() {
         for (Class<?> preInstantiateBean : preInstantiateBeans) {
-            initializeInjectedBean(preInstantiateBean);
+            Class concreteClass = findConcreteClass(preInstantiateBean);
+            beans.put(concreteClass, createBean(concreteClass));
         }
     }
 
-    private void initializeInjectedBean(Class clazz) {
+    private Object createBean(Class clazz) {
         if (beans.containsKey(clazz)) {
-            return;
+            return beans.get(clazz);
         }
 
-        Class concreteClass = findConcreteClass(clazz);
-        Object injectedBean = createInjectedInstance(concreteClass);
-
-        beans.put(concreteClass, injectedBean);
+        return createInjectedInstance(clazz);
     }
 
     private Object createInjectedInstance(Class concreteClass) {
@@ -86,11 +84,8 @@ public class BeanFactory {
         List<Object> parameters = new ArrayList<>();
         for (Class<?> parameterType : injectedConstructor.getParameterTypes()) {
             Class parameter = findConcreteClass(parameterType);
-
-            if (!beans.containsKey(parameter)) {
-                initializeInjectedBean(parameter);
-            }
-            parameters.add(beans.get(parameter));
+            Object bean = createBean(parameter);
+            parameters.add(bean);
         }
 
         return parameters;

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanFactoryUtils.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Sets;
 import nextstep.annotation.Inject;
 
 import java.lang.reflect.Constructor;
+import java.util.Map;
 import java.util.Set;
 
 import static org.reflections.ReflectionUtils.getAllConstructors;
@@ -52,5 +53,22 @@ public class BeanFactoryUtils {
         }
 
         throw new IllegalStateException(injectedClazz + "인터페이스를 구현하는 Bean이 존재하지 않는다.");
+    }
+
+    public static BeanDefinition findBeanDefinition(Class<?> clazz, Map<Class<?>, BeanDefinition> beanDefinitions) {
+        if (beanDefinitions.containsKey(clazz)) {
+            return beanDefinitions.get(clazz);
+        }
+
+        if (clazz.isInterface()) {
+            for (Class<?> beanDefinitionKey : beanDefinitions.keySet()) {
+                Set<Class<?>> interfaces = Sets.newHashSet(beanDefinitionKey.getInterfaces());
+                if (interfaces.contains(clazz)) {
+                    return beanDefinitions.get(beanDefinitionKey);
+                }
+            }
+        }
+
+        throw new IllegalStateException(clazz + "인터페이스를 구현하는 Bean이 존재하지 않는다.");
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -18,22 +18,6 @@ public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scan(String basePackage) {
-        Reflections reflections = new Reflections(basePackage);
-        return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation>... annotations) {
-        Set<Class<?>> beans = Sets.newHashSet();
-        for (Class<? extends Annotation> annotation : annotations) {
-            beans.addAll(reflections.getTypesAnnotatedWith(annotation));
-        }
-        log.debug("Scan Beans Type : {}", beans);
-        return beans;
-    }
-
-    @SuppressWarnings("unchecked")
     public static Set<Class<?>> scanConfiguration(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
 
@@ -52,5 +36,21 @@ public class BeanScanner {
 
         scannedComponents.addAll(configurations);
         return scannedComponents;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Set<Class<?>> scan(String basePackage) {
+        Reflections reflections = new Reflections(basePackage);
+        return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class, Configuration.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation>... annotations) {
+        Set<Class<?>> beans = Sets.newHashSet();
+        for (Class<? extends Annotation> annotation : annotations) {
+            beans.addAll(reflections.getTypesAnnotatedWith(annotation));
+        }
+        log.debug("Scan Beans Type : {}", beans);
+        return beans;
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -1,6 +1,8 @@
 package nextstep.di.factory;
 
 import com.google.common.collect.Sets;
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
 import nextstep.stereotype.Controller;
 import nextstep.stereotype.Repository;
 import nextstep.stereotype.Service;
@@ -10,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
@@ -28,5 +31,26 @@ public class BeanScanner {
         }
         log.debug("Scan Beans Type : {}", beans);
         return beans;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Set<Class<?>> scanConfiguration(String basePackage) {
+        Reflections reflections = new Reflections(basePackage);
+
+        Set<Class<?>> scannedComponents = Sets.newHashSet();
+        Set<Class<?>> configurations = getTypesAnnotatedWith(reflections, Configuration.class);
+
+        for (Class<?> configuration : configurations) {
+            ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
+
+            if (componentScan != null) {
+                Stream.of(componentScan.value())
+                        .map(BeanScanner::scan)
+                        .forEach(scannedComponents::addAll);
+            }
+        }
+
+        scannedComponents.addAll(configurations);
+        return scannedComponents;
     }
 }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -11,35 +11,61 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 public class BeanScanner {
     private static final Logger log = LoggerFactory.getLogger(BeanScanner.class);
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scanConfiguration(String basePackage) {
+    public static Set<Class<?>> scan(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
 
-        Set<Class<?>> scannedComponents = Sets.newHashSet();
         Set<Class<?>> configurations = getTypesAnnotatedWith(reflections, Configuration.class);
-
-        for (Class<?> configuration : configurations) {
-            ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
-
-            if (componentScan != null) {
-                Stream.of(componentScan.value())
-                        .map(BeanScanner::scan)
-                        .forEach(scannedComponents::addAll);
-            }
-        }
-
+        Set<Class<?>> scannedComponents = scanPackagesOfComponentScan(configurations);
         scannedComponents.addAll(configurations);
+
+        return scannedComponents;
+    }
+
+    private static Set<Class<?>> scanPackagesOfComponentScan(Set<Class<?>> configurations) {
+        Set<Class<?>> scanResult = Sets.newHashSet();
+
+        configurations.stream()
+                .map(BeanScanner::scanOfTargetPackages)
+                .forEach(scanResult::addAll);
+
+        return scanResult;
+    }
+
+    private static Set<Class<?>> scanOfTargetPackages(Class<?> configuration) {
+        List<String> targetPackages = getTargetPackages(configuration);
+
+        return scanComponents(targetPackages);
+    }
+
+    private static List<String> getTargetPackages(Class<?> configuration) {
+        ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
+
+        return componentScan != null
+                ? Arrays.asList(componentScan.value())
+                : Arrays.asList(configuration.getPackage().getName());
+    }
+
+    private static Set<Class<?>> scanComponents(List<String> targetPackages) {
+        Set<Class<?>> scannedComponents = new HashSet<>();
+
+        targetPackages.stream()
+                .map(BeanScanner::scanPackage)
+                .forEach(scannedComponents::addAll);
+
         return scannedComponents;
     }
 
     @SuppressWarnings("unchecked")
-    public static Set<Class<?>> scan(String basePackage) {
+    public static Set<Class<?>> scanPackage(String basePackage) {
         Reflections reflections = new Reflections(basePackage);
         return getTypesAnnotatedWith(reflections, Controller.class, Service.class, Repository.class, Configuration.class);
     }
@@ -47,9 +73,11 @@ public class BeanScanner {
     @SuppressWarnings("unchecked")
     private static Set<Class<?>> getTypesAnnotatedWith(Reflections reflections, Class<? extends Annotation>... annotations) {
         Set<Class<?>> beans = Sets.newHashSet();
+
         for (Class<? extends Annotation> annotation : annotations) {
             beans.addAll(reflections.getTypesAnnotatedWith(annotation));
         }
+
         log.debug("Scan Beans Type : {}", beans);
         return beans;
     }

--- a/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
+++ b/nextstep-di/src/main/java/nextstep/di/factory/BeanScanner.java
@@ -1,5 +1,6 @@
 package nextstep.di.factory;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import nextstep.annotation.ComponentScan;
 import nextstep.annotation.Configuration;
@@ -49,9 +50,14 @@ public class BeanScanner {
     private static List<String> getTargetPackages(Class<?> configuration) {
         ComponentScan componentScan = configuration.getAnnotation(ComponentScan.class);
 
-        return componentScan != null
-                ? Arrays.asList(componentScan.value())
-                : Arrays.asList(configuration.getPackage().getName());
+        if (componentScan == null) {
+            return Lists.newArrayList();
+        }
+
+        String[] targetPackages = componentScan.value();
+        return targetPackages.length == 0
+                ? Arrays.asList(configuration.getPackage().getName())
+                : Arrays.asList(targetPackages);
     }
 
     private static Set<Class<?>> scanComponents(List<String> targetPackages) {

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanDefinitionFactoryTest.java
@@ -1,0 +1,54 @@
+package nextstep.di.factory;
+
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.controller.QnaController;
+import org.assertj.core.util.Sets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class BeanDefinitionFactoryTest {
+    @Test
+    @DisplayName("Scan한 클래스로부터 BeanDefinition을 생성한다.")
+    void createBeanDefinition() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(ExampleConfig.class, QnaController.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        assertNotNull(beanDefinitions.get(ExampleConfig.class));
+        assertNotNull(beanDefinitions.get(QnaController.class));
+        assertNotNull(beanDefinitions.get(DataSource.class));
+    }
+
+    @Test
+    @DisplayName("Bean이 Configuration을 통해 생성되는 경우, 생성된 BeanDefinition의 configType은 해당 Configuration 클래스다.")
+    void checkConfigType_ifBeanIsGeneratedByConfiguration() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(ExampleConfig.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        BeanDefinition dataSourceBeanDefinition = beanDefinitions.get(DataSource.class);
+        assertThat(dataSourceBeanDefinition.getConfigType()).isEqualTo(ExampleConfig.class);
+    }
+
+    @Test
+    @DisplayName("Configuration에서 생성하는 bean이 아닌 경우, BeanDefinition의 configType은 null이다.")
+    void createBeanDefinitio() {
+        Set<Class<?>> preInstantiateClazz = Sets.newHashSet(Arrays.asList(QnaController.class));
+        Map<Class<?>, BeanDefinition> beanDefinitions = createBeanDefinitions(preInstantiateClazz);
+
+        BeanDefinition qnaControllerBeanDefinition = beanDefinitions.get(QnaController.class);
+        assertNull(qnaControllerBeanDefinition.getConfigType());
+    }
+
+    private Map<Class<?>, BeanDefinition> createBeanDefinitions(Set<Class<?>> preInstantiateClazz) {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
+        return beanDefinitionFactory.createBeanDefinition();
+    }
+}

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -21,7 +21,7 @@ class BeanFactoryTest {
 
     @BeforeEach
     void setup() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example.config");
         BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
         beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
         beanFactory.initialize();

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryTest.java
@@ -1,12 +1,16 @@
 package nextstep.di.factory;
 
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.config.IntegrationConfig;
 import nextstep.di.factory.example.controller.QnaController;
+import nextstep.di.factory.example.repository.MyJdbcTemplate;
 import nextstep.di.factory.example.service.MyQnaService;
 import nextstep.di.factory.example.service.TestService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -17,8 +21,9 @@ class BeanFactoryTest {
 
     @BeforeEach
     void setup() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
-        beanFactory = new BeanFactory(preInstantiateClazz);
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        BeanDefinitionFactory definitionFactory = new BeanDefinitionFactory(preInstantiateClazz);
+        beanFactory = new BeanFactory(definitionFactory.createBeanDefinition());
         beanFactory.initialize();
     }
 
@@ -41,5 +46,17 @@ class BeanFactoryTest {
 
         assertNotNull(testService);
         assertNotNull(testService.getMyQnaService());
+    }
+
+    @Test
+    @DisplayName("Configuration 클래스를 통해 bean을 등록한다.")
+    void beanCreationByConfiguration() {
+        assertNotNull(beanFactory.getBean(DataSource.class));
+        assertNotNull(beanFactory.getBean(ExampleConfig.class));
+
+        assertNotNull(beanFactory.getBean(IntegrationConfig.class));
+        assertNotNull(beanFactory.getBean(DataSource.class));
+        assertNotNull(beanFactory.getBean(MyJdbcTemplate.class));
+
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -44,7 +44,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfInterface() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
@@ -54,7 +54,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
     void findConcreteDefinitionOfClass() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
@@ -64,7 +64,7 @@ class BeanFactoryUtilsTest {
     @Test
     @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
     void failToFindDefinition() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("nextstep.di.factory.example"));
         Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
 
         assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanFactoryUtilsTest.java
@@ -2,12 +2,16 @@ package nextstep.di.factory;
 
 import nextstep.di.factory.example.controller.QnaController;
 import nextstep.di.factory.example.repository.JdbcQuestionRepository;
+import nextstep.di.factory.example.repository.JdbcUserRepository;
+import nextstep.di.factory.example.repository.UserRepository;
 import nextstep.di.factory.example.service.MyQnaService;
 import nextstep.di.factory.outside.MultipleInjectedService;
+import nextstep.di.factory.outside.OutsideService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,5 +39,35 @@ class BeanFactoryUtilsTest {
     @DisplayName("@Inject 애너테이션이 없는 경우에는 null을 반환한다.")
     void getInjectedConstructor_IfInjectedConstructorIsEmpty_returnNull() {
         assertNull(BeanFactoryUtils.getInjectedConstructor(JdbcQuestionRepository.class));
+    }
+
+    @Test
+    @DisplayName("인터페이스에 대한 BeanDefinition을 찾아준다.")
+    void findConcreteDefinitionOfInterface() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(UserRepository.class, definitions);
+        assertThat(beanDefinition.getType()).isEqualTo(JdbcUserRepository.class);
+    }
+
+    @Test
+    @DisplayName("해당하는 클래스에 대한 BeanDefinition을 찾아준다.")
+    void findConcreteDefinitionOfClass() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        BeanDefinition beanDefinition = BeanFactoryUtils.findBeanDefinition(MyQnaService.class, definitions);
+        assertThat(beanDefinition.getType()).isEqualTo(MyQnaService.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 BeanDefinition을 찾는 경우 예외를 던진다.")
+    void failToFindDefinition() {
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("nextstep.di.factory.example"));
+        Map<Class<?>, BeanDefinition> definitions = beanDefinitionFactory.createBeanDefinition();
+
+        assertThatThrownBy(() -> BeanFactoryUtils.findBeanDefinition(OutsideService.class, definitions))
+                .isInstanceOf(IllegalStateException.class);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -1,6 +1,8 @@
 package nextstep.di.factory;
 
 import nextstep.di.factory.example.TestApplication;
+import nextstep.di.factory.example.config.ExampleConfig;
+import nextstep.di.factory.example.config.IntegrationConfig;
 import nextstep.di.factory.example.controller.QnaController;
 import nextstep.di.factory.example.repository.JdbcQuestionRepository;
 import nextstep.di.factory.example.repository.JdbcUserRepository;
@@ -51,5 +53,22 @@ public class BeanScannerTest {
         Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
+    }
+
+    @Test
+    @DisplayName("빈 설정 파일을 스캔한다.")
+    void configurationScan() {
+        Set<Class<?>> configurations = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+
+        assertThat(configurations).contains(
+                ExampleConfig.class,
+                IntegrationConfig.class,
+                QnaController.class,
+                MyQnaService.class,
+                TestService.class,
+                JdbcQuestionRepository.class,
+                JdbcUserRepository.class
+        );
+        assertThat(configurations.size()).isEqualTo(7);
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -23,7 +23,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("scan메서드에 패키지명을 넣어주면 해당 패키지의 @Controller, @Service, @Repository 구현 클래스를 스캔한다.")
     void scanAll() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanPackage("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).contains(
                 QnaController.class,
@@ -38,7 +38,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("scan 메서드에 해당하는 패키지와 하위 패키지 이외의 클래스는 스캔하지 않는다.")
     void notScanOutsideOfPackage() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanPackage("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).doesNotContain(
                 OutsideController.class,
@@ -50,7 +50,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("@Controller, @Service, @Repository 이외의 애노테이션이 선언된 클래스는 스캔하지 않는다.")
     void ignoreInvalidAnnotation() {
-        Set<Class<?>> preInstantiateClazz = BeanScanner.scan("nextstep.di.factory.example");
+        Set<Class<?>> preInstantiateClazz = BeanScanner.scanPackage("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).doesNotContain(TestApplication.class);
     }
@@ -58,7 +58,7 @@ public class BeanScannerTest {
     @Test
     @DisplayName("빈 설정 파일을 스캔한다.")
     void configurationScan() {
-        Set<Class<?>> configurations = BeanScanner.scanConfiguration("nextstep.di.factory.example.config");
+        Set<Class<?>> configurations = BeanScanner.scan("nextstep.di.factory.example");
 
         assertThat(configurations).contains(
                 ExampleConfig.class,

--- a/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/BeanScannerTest.java
@@ -8,6 +8,7 @@ import nextstep.di.factory.example.repository.JdbcQuestionRepository;
 import nextstep.di.factory.example.repository.JdbcUserRepository;
 import nextstep.di.factory.example.service.MyQnaService;
 import nextstep.di.factory.example.service.TestService;
+import nextstep.di.factory.outside.MultipleInjectedService;
 import nextstep.di.factory.outside.OutsideController;
 import nextstep.di.factory.outside.OutsideRepository;
 import nextstep.di.factory.outside.OutsideService;
@@ -26,13 +27,15 @@ public class BeanScannerTest {
         Set<Class<?>> preInstantiateClazz = BeanScanner.scanPackage("nextstep.di.factory.example");
 
         assertThat(preInstantiateClazz).contains(
+                ExampleConfig.class,
+                IntegrationConfig.class,
                 QnaController.class,
                 MyQnaService.class,
                 TestService.class,
                 JdbcQuestionRepository.class,
                 JdbcUserRepository.class
         );
-        assertThat(preInstantiateClazz.size()).isEqualTo(5);
+        assertThat(preInstantiateClazz.size()).isEqualTo(7);
     }
 
     @Test
@@ -70,5 +73,18 @@ public class BeanScannerTest {
                 JdbcUserRepository.class
         );
         assertThat(configurations.size()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("@Configuration에 @ComponentScan이 없는 경우 스캔이 이뤄지지 않는다.")
+    void notExistComponentScan() {
+        Set<Class<?>> configurations = BeanScanner.scan("nextstep.di.factory.outside");
+
+        assertThat(configurations).doesNotContain(
+                OutsideController.class,
+                OutsideService.class,
+                OutsideRepository.class,
+                MultipleInjectedService.class
+        );
     }
 }

--- a/nextstep-di/src/test/java/nextstep/di/factory/example/config/ExampleConfig.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/example/config/ExampleConfig.java
@@ -1,12 +1,14 @@
 package nextstep.di.factory.example.config;
 
 import nextstep.annotation.Bean;
+import nextstep.annotation.ComponentScan;
 import nextstep.annotation.Configuration;
 import org.apache.commons.dbcp2.BasicDataSource;
 
 import javax.sql.DataSource;
 
 @Configuration
+@ComponentScan("nextstep.di.factory.example")
 public class ExampleConfig {
     @Bean
     public DataSource dataSource() {

--- a/nextstep-di/src/test/java/nextstep/di/factory/outside/OutsideApplication.java
+++ b/nextstep-di/src/test/java/nextstep/di/factory/outside/OutsideApplication.java
@@ -1,0 +1,7 @@
+package nextstep.di.factory.outside;
+
+import nextstep.annotation.Configuration;
+
+@Configuration
+public class OutsideApplication {
+}

--- a/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -17,7 +17,7 @@ public class AnnotationHandlerMappingTest {
 
     @BeforeEach
     public void setup() {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("samples"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("samples"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
 
         beanFactory.initialize();

--- a/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
+++ b/nextstep-mvc/src/test/java/nextstep/mvc/tobe/AnnotationHandlerMappingTest.java
@@ -1,6 +1,7 @@
 package nextstep.mvc.tobe;
 
 import nextstep.db.DataBase;
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +17,9 @@ public class AnnotationHandlerMappingTest {
 
     @BeforeEach
     public void setup() {
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("samples"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("samples"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
+
         beanFactory.initialize();
         handlerMapping = new AnnotationHandlerMapping(beanFactory);
 

--- a/nextstep-mvc/src/test/java/samples/SampleApplication.java
+++ b/nextstep-mvc/src/test/java/samples/SampleApplication.java
@@ -1,0 +1,9 @@
+package samples;
+
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
+
+@Configuration
+@ComponentScan("samples")
+public class SampleApplication {
+}

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -1,5 +1,6 @@
 package slipp;
 
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import nextstep.mvc.DispatcherServlet;
@@ -19,7 +20,8 @@ public class SlippWebApplicationInitializer  implements WebApplicationInitialize
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 
         DispatcherServlet dispatcherServlet = new DispatcherServlet();

--- a/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
+++ b/slipp/src/main/java/slipp/SlippWebApplicationInitializer.java
@@ -20,7 +20,7 @@ public class SlippWebApplicationInitializer  implements WebApplicationInitialize
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 

--- a/slipp/src/main/java/slipp/WebServerLauncher.java
+++ b/slipp/src/main/java/slipp/WebServerLauncher.java
@@ -1,11 +1,15 @@
 package slipp;
 
+import nextstep.annotation.ComponentScan;
+import nextstep.annotation.Configuration;
 import org.apache.catalina.startup.Tomcat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+@Configuration
+@ComponentScan
 public class WebServerLauncher {
     private static final Logger logger = LoggerFactory.getLogger(WebServerLauncher.class);
 

--- a/slipp/src/test/java/slipp/DispatcherServletTest.java
+++ b/slipp/src/test/java/slipp/DispatcherServletTest.java
@@ -1,5 +1,6 @@
 package slipp;
 
+import nextstep.di.factory.BeanDefinitionFactory;
 import nextstep.di.factory.BeanFactory;
 import nextstep.di.factory.BeanScanner;
 import nextstep.jdbc.ConnectionManager;
@@ -30,7 +31,8 @@ class DispatcherServletTest {
         populator.addScript(new ClassPathResource("jwp.sql"));
         DatabasePopulatorUtils.execute(populator, ConnectionManager.getDataSource());
 
-        BeanFactory beanFactory = new BeanFactory(BeanScanner.scan("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 
         dispatcher = new DispatcherServlet();

--- a/slipp/src/test/java/slipp/DispatcherServletTest.java
+++ b/slipp/src/test/java/slipp/DispatcherServletTest.java
@@ -31,7 +31,7 @@ class DispatcherServletTest {
         populator.addScript(new ClassPathResource("jwp.sql"));
         DatabasePopulatorUtils.execute(populator, ConnectionManager.getDataSource());
 
-        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scanConfiguration("slipp"));
+        BeanDefinitionFactory beanDefinitionFactory = new BeanDefinitionFactory(BeanScanner.scan("slipp"));
         BeanFactory beanFactory = new BeanFactory(beanDefinitionFactory.createBeanDefinition());
         beanFactory.initialize();
 


### PR DESCRIPTION
안녕하세요 하비! 제출이 늦어져서 죄송합니다 ㅠㅠ

Configuration에서 정의한 빈과 ComponentScan을 통해 만드는 빈의 관계에 대해 계속해서 고민하다 보니까 이렇게 늦어졌네요...

구현한 결과 빈을 다음과 같이 등록하고 있습니다.

- BasePackage는 @Configuration이 선언된 클래스에서 @ComponentScan의 value값으로 선언된 경로로 컴포넌트들을 찾고 있습니다.
- BeanScanner는 @ComponentScan으로 선언된 BasePackage 경로의 컴포넌트와 @Configuration이 선언된 클래스들의 클래스 타입을 스캔합니다.
- BeanDefinitionFactory는 BeanScanner를 통해 스캔된 클래스들의 BeanDefinition을 생성합니다. BeanDefinition은 해당 클래스 타입과 생성 방법 등을 저장하고 있습니다. 그리고 이 팩토리에서 @Configuration 클래스의 BeanDefinition뿐 아니라 내부의 @Bean으로 선언된 메서드를 빈으로 등록하기 위한 BeanDefinition도 저장하고 있습니다.
- BeanFactory는 위에서 만들어진 BeanDefinition을 가지고 빈을 생성하여 beans에 등록합니다.

이 과정에서 저희가 고민을 많이했던 부분이 `@Controller`, `@Service`, `@Repository` 등 컴포넌트 빈을 생성할 때와 `@Bean`으로 생성할 때가 상이하다는 점이었습니다.

전자는 해당 클래스 정보를 가져와 Constructor를 파악하여 생성하면 됐었습니다. 반면 후자는 메서드를 invoke하도록 해야했기 때문에 이를 정의한 configuration 빈 인스턴스을 넘겨서 처리해야한다는 결론이 났습니다. 때문에 현재는 BeanCreator에 두가지 파라미터를 주어 첫번째 인자가 null이라면 전자의 방식으로 생성하고 null이 아니라면 후자의 방식으로 생성하도록 만들었습니다.

이 부분을 개선하고 싶은데 잘 생각이 나지 않네요... 하비의 생각이 궁금합니다!